### PR TITLE
Fixed invalid `usage key` errors which previously throw 500.

### DIFF
--- a/cms/djangoapps/contentstore/views/component.py
+++ b/cms/djangoapps/contentstore/views/component.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_GET
 from django.core.exceptions import PermissionDenied
 from django.conf import settings
+from opaque_keys import InvalidKeyError
 from xmodule.modulestore.exceptions import ItemNotFoundError
 from edxmako.shortcuts import render_to_response
 
@@ -155,7 +156,10 @@ def container_handler(request, usage_key_string):
     """
     if 'text/html' in request.META.get('HTTP_ACCEPT', 'text/html'):
 
-        usage_key = UsageKey.from_string(usage_key_string)
+        try:
+            usage_key = UsageKey.from_string(usage_key_string)
+        except InvalidKeyError:  # Raise Http404 on invalid 'usage_key_string'
+            raise Http404
         with modulestore().bulk_operations(usage_key.course_key):
             try:
                 course, xblock, lms_link, preview_lms_link = _get_item_in_course(request, usage_key)

--- a/cms/djangoapps/contentstore/views/tests/test_container_page.py
+++ b/cms/djangoapps/contentstore/views/tests/test_container_page.py
@@ -1,14 +1,19 @@
 """
 Unit tests for the container page.
 """
-
 import re
 import datetime
 from pytz import UTC
+from mock import patch, Mock
+
+from django.http import Http404
+from django.test.client import RequestFactory
+from django.utils import http
+
+import contentstore.views.component as views
 from contentstore.views.tests.utils import StudioPageTestCase
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.factories import ItemFactory
-from django.utils import http
 
 
 class ContainerPageTestCase(StudioPageTestCase):
@@ -158,3 +163,25 @@ class ContainerPageTestCase(StudioPageTestCase):
         """
         empty_child_container = self._create_item(self.vertical.location, 'split_test', 'Split Test')
         self.validate_preview_html(empty_child_container, self.reorderable_child_view, can_add=False)
+
+    @patch('contentstore.views.component.render_to_response', Mock(return_value=Mock(status_code=200, content='')))
+    def test_container_page_with_valid_and_invalid_usage_key_string(self):
+        """
+        Check that invalid 'usage_key_string' raises Http404.
+        """
+        request = RequestFactory().get('foo')
+        request.user = self.user
+
+        # Check for invalid 'usage_key_strings'
+        self.assertRaises(
+            Http404, views.container_handler,
+            request,
+            usage_key_string='i4x://InvalidOrg/InvalidCourse/vertical/static/InvalidContent',
+            )
+
+        # Check 200 response if 'usage_key_string' is correct
+        response = views.container_handler(
+            request=request,
+            usage_key_string=self.vertical.location.to_deprecated_string()
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
[TNL-473] (https://openedx.atlassian.net/browse/TNL-473)

URLs with invalid `usage_key_string` on the container page should return Http404 (Not Found) instead of 500.
Added try/catch check on where `usage_key_string` is transformed to `OpaqueKey` object.

Added Unit test to check container page with valid and invalid `usage_key_string`.